### PR TITLE
Fix/Authentication errors

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -19,6 +19,12 @@ export class AuthService {
     private readonly jwtService: JwtService,
   ) {}
 
+  /* 
+    When you are hashing your data the module will go through a series of rounds to give you a secure hash. 
+    The value you submit here will be used to go through 2^rounds iterations of processing.
+  */
+  private saltRounds = 10;
+
   async signUp(dto: AuthDto) {
     const { password, email } = dto;
     const user = await this.authRepo.findOneBy({ email });
@@ -27,7 +33,7 @@ export class AuthService {
       throw new ConflictException('User already exists');
     }
 
-    const salt = await genSalt(10);
+    const salt = await genSalt(this.saltRounds);
     const hashPassword = await hash(password, salt);
 
     const createdUser = await this.authRepo.save({


### PR DESCRIPTION
Hi Luda,

I've made the following hotfixes to make the frontend PR [#15](https://github.com/ZenBit-Tech/HiveIn_fe/pull/15) work as intended:

- Local sign-in returns different status codes depending on the error
- Hashing is now async (recommended in their docs)

> Why is async mode recommended over sync mode? 
> If you are using bcrypt on a simple script, using the sync mode is perfectly  fine. However, if you are using bcrypt on a server, the async mode is recommended. This is because the hashing done by bcrypt is CPU intensive, so the sync version will block the event loop and prevent your application from servicing any other inbound requests or events. The async version uses a thread pool which does not block the main event loop.