### PR TITLE
fix: Secured update and delete user endpoints

### DIFF
--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -12,7 +12,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
       secretOrKey: process.env.SECRET_KEY,
     });
   }
-  async validate(payload) {
-    return payload;
+  async validate({ sub, email }) {
+    return { id: sub, email };
   }
 }

--- a/src/modules/freelancer/freelancer.controller.ts
+++ b/src/modules/freelancer/freelancer.controller.ts
@@ -6,16 +6,21 @@ import {
   Patch,
   Param,
   Delete,
+  Req,
+  UseGuards,
 } from '@nestjs/common';
 import { FreelancerService } from './freelancer.service';
 import { CreateFreelancerDto } from './dto/create-freelancer.dto';
 import { UpdateFreelancerDto } from './dto/update-freelancer.dto';
 import { Freelancer } from './entities/freelancer.entity';
+import { PassportReq } from 'src/modules/settings-info/settings-info.controller';
+import { JwtAuthGuard } from 'src/modules/auth/guards/jwt-auth.guard';
 
 @Controller('freelancer')
 export class FreelancerController {
   constructor(private readonly freelancerService: FreelancerService) {}
 
+  @UseGuards(JwtAuthGuard)
   @Post()
   create(
     @Body() createFreelancerDto: CreateFreelancerDto,
@@ -23,16 +28,26 @@ export class FreelancerController {
     return this.freelancerService.create(createFreelancerDto);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Get()
   findAll(): Promise<Freelancer[]> {
     return this.freelancerService.findAll();
   }
 
+  @UseGuards(JwtAuthGuard)
+  @Get('self')
+  findOwn(@Req() req: PassportReq): Promise<Freelancer> {
+    const { id } = req.user;
+    return this.freelancerService.findOneByUserId(+id);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string): Promise<Freelancer> {
     return this.freelancerService.findOneByUserId(+id);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Patch(':id')
   update(
     @Param('id') id: string,
@@ -41,6 +56,7 @@ export class FreelancerController {
     return this.freelancerService.update(+id, updateFreelancerDto);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Delete(':id')
   remove(@Param('id') id: string): Promise<void> {
     return this.freelancerService.remove(+id);

--- a/src/modules/job-post/job-post.controller.ts
+++ b/src/modules/job-post/job-post.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Req,
   Res,
   UploadedFile,
   UseGuards,
@@ -19,8 +20,9 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
 import { ApiTags } from '@nestjs/swagger';
 import { LocalFilesService } from './localFiles.service';
-import type { Response } from 'express';
+import { Response } from 'express';
 import { JobPost } from './entities/job-post.entity';
+import { PassportReq } from 'src/modules/settings-info/settings-info.controller';
 
 @ApiTags('JobPost')
 @Controller('job-post')
@@ -66,15 +68,16 @@ export class JobPostController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.jobPostService.findOne(+id);
+  @Get('self')
+  findByUser(@Req() req: PassportReq) {
+    const { id } = req.user;
+    return this.jobPostService.findByUser(+id);
   }
 
   @UseGuards(JwtAuthGuard)
-  @Get('user/:id')
-  findByUser(@Param('id') id: string) {
-    return this.jobPostService.findByUser(+id);
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.jobPostService.findOne(+id);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -84,11 +87,12 @@ export class JobPostController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Get('home/:id/:isDraft')
+  @Get('home/self/:isDraft')
   getClientHomePostsAndDrafts(
-    @Param('id') id: number,
+    @Req() req: PassportReq,
     @Param('isDraft') isDraft?: string,
   ) {
+    const { id } = req.user;
     return this.jobPostService.getClientHomePostAndDrafts(
       id,
       isDraft === 'true' ? true : false,

--- a/src/modules/settings-info/settings-info.controller.ts
+++ b/src/modules/settings-info/settings-info.controller.ts
@@ -7,11 +7,20 @@ import {
   Param,
   Delete,
   UseGuards,
+  Req,
 } from '@nestjs/common';
 import { SettingsInfoService } from './settings-info.service';
 import { CreateSettingsInfoDto } from './dto/create-settings-info.dto';
 import { UpdateSettingsInfoDto } from './dto/update-settings-info.dto';
 import { JwtAuthGuard } from 'src/modules/auth/guards/jwt-auth.guard';
+import { Request } from 'express';
+
+export interface PassportReq extends Request {
+  user: {
+    id: number;
+    email: string;
+  };
+}
 
 @Controller('settings-info')
 export class SettingsInfoController {
@@ -30,23 +39,32 @@ export class SettingsInfoController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Get('self')
+  findOwnUser(@Req() req: PassportReq) {
+    const { id } = req.user;
+    return this.settingsInfoService.findOne(+id);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.settingsInfoService.findOne(+id);
   }
 
   @UseGuards(JwtAuthGuard)
-  @Patch(':id')
+  @Patch('self')
   update(
-    @Param('id') id: string,
+    @Req() req: PassportReq,
     @Body() updateSettingsInfoDto: UpdateSettingsInfoDto,
   ) {
+    const { id } = req.user;
     return this.settingsInfoService.update(+id, updateSettingsInfoDto);
   }
 
   @UseGuards(JwtAuthGuard)
-  @Delete(':id')
-  remove(@Param('id') id: string) {
+  @Delete('self')
+  remove(@Req() req: PassportReq) {
+    const { id } = req.user;
     return this.settingsInfoService.remove(+id);
   }
 }


### PR DESCRIPTION
This PR was made with the intention of securing endpoints that change the user table. Clients that once could update or delete any user with their JWT now can only do that with their own

- /self endpoints created for controllers that update and delete the user table. Requested in the [#33](https://github.com/ZenBit-Tech/HiveIn_fe/pull/33) PR
- Freelancer endpoints also had no JWT guards, so I've added them